### PR TITLE
openjpeg 2.1.2 - rev. 2.

### DIFF
--- a/mingw-w64-openjpeg2/PKGBUILD
+++ b/mingw-w64-openjpeg2/PKGBUILD
@@ -4,7 +4,7 @@ _realname=openjpeg
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}2"
 pkgver=2.1.2
-pkgrel=1
+pkgrel=2
 pkgdesc="An open source JPEG 2000 codec (mingw-w64)"
 arch=('any')
 url="http://www.openjpeg.org"
@@ -18,11 +18,12 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
              "${MINGW_PACKAGE_PREFIX}-cmake")
 options=('staticlibs' 'strip')
-source=(${_realname}-${pkgver}.tar.gz::https://github.com/uclouvain/openjpeg/archive/v${pkgver}.tar.gz
+source=(https://github.com/uclouvain/openjpeg/archive/v$pkgver.tar.gz
         0001-fix-install-for-dlls.all.patch
         0003-versioned-dlls.mingw.patch
         0005-sock-jpip.all.patch
         0006-openjpeg-2.1.0-stdcall-for-all-win.patch)
+
 sha256sums=('4ce77b6ef538ef090d9bde1d5eeff8b3069ab56c4906f083475517c2c023dfa7'
             '3f3bde353ca3432f157258164c5e3c345af82ca3a9d5a68f815c3030b01cbc32'
             'a221300d278f1a57b1ea5c70314702cd4234a2560ed2335bd5940fd921e78eda'
@@ -34,7 +35,7 @@ prepare() {
   patch -p1 -i ${srcdir}/0001-fix-install-for-dlls.all.patch
   patch -p1 -i ${srcdir}/0003-versioned-dlls.mingw.patch
   patch -p1 -i ${srcdir}/0005-sock-jpip.all.patch
-#  patch -p1 -i ${srcdir}/0006-openjpeg-2.1.0-stdcall-for-all-win.patch
+  patch -p1 -i ${srcdir}/0006-openjpeg-2.1.0-stdcall-for-all-win.patch
 }
 
 build() {
@@ -73,10 +74,11 @@ build() {
     -DCMAKE_SYSTEM_PREFIX_PATH=${MINGW_PREFIX} \
     -DBUILD_MJ2=ON \
     -DBUILD_JPWL=ON \
-    -DBUILD_JPIP=ON \
+    -DBUILD_JPIP=OFF \
     -DBUILD_JP3D=ON \
     -DBUILD_DOC=OFF \
     -DBUILD_PKGCONFIG_FILES=ON \
+    -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=TRUE \
     ../${_realname}-${pkgver}
   make
 }


### PR DESCRIPTION
Drop JPIP.  For some reason, that causes build failures and I don't know
why it is.